### PR TITLE
Added support for custom documentation build scripts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,14 +48,14 @@ Here's an example documentation build command you might specify for
 `build-shared-docs` if you'd defined a `documentation.yml` file to
 organize the documentation:
 ```
-NAME=${NAME:-"$(npm view . name)"} VERSION=${VERSION:-"$(npm view . version)"} OUTPUT=${OUTPUT:-\"./docs\"} && \
+NAME=${NAME:-"$(npm view . name)"} VERSION=${VERSION:-"$(npm view . version)"} OUTPUT=${OUTPUT:-"./docs"} && \
     documentation build src/*.js --github --format html --output ${OUTPUT} \
     --name ${NAME} --project-version ${VERSION} --config documentation.yml
 ```
-The conditional definitions of `NAME`, `VERSION` and `OUTPUT` allow it
-to also be invoked directly using `npm run build-shared-docs`. (To use
-this as a script, you'd need to remove the line breaks and escape the
-quotes.)
+The conditional definitions of `NAME`, `VERSION` and `OUTPUT` allow the
+script to also be invoked directly using `npm run build-shared-docs`.
+(To specify this command as a `package.json` script, you'd need to
+remove the line breaks and escape the quotes.)
 
 ### Serve the docs
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,39 @@ To build a new local copy of the docs:
 > npm run build-docs
 ```
 
+This will build the documentation for each module in the `modules`
+folder and place the output in a subfolder of the `docs` folder.
+
+If the module's `package.json` file defines a `build-shared-docs`
+script, it will be used to build the documentation for the module.
+If no script is defined, `documentation` will be invoked directly to
+build the documentation.
+
+These environment variables are available to the script:
+*   `MODULE` - the module subfolder name
+*   `NAME` - the module name (from `name` in `package.json`)
+*   `VERSION` - the module version (from `version` in `package.json`)
+*   `OUTPUT` - the `docs` subfolder output path (where the script should place the documentation)
+
+Here's the default documentation build script:
+```
+documentation build src/*.js --github --format html --output ${OUTPUT} \
+    --name ${NAME} --project-version ${VERSION} --external nxus-*
+```
+
+Here's an example documentation build command you might specify for
+`build-shared-docs` if you'd defined a `documentation.yml` file to
+organize the documentation:
+```
+NAME=${NAME:-"$(npm view . name)"} VERSION=${VERSION:-"$(npm view . version)"} OUTPUT=${OUTPUT:-\"./docs\"} && \
+    documentation build src/*.js --github --format html --output ${OUTPUT} \
+    --name ${NAME} --project-version ${VERSION} --config documentation.yml
+```
+The conditional definitions of `NAME`, `VERSION` and `OUTPUT` allow it
+to also be invoked directly using `npm run build-shared-docs`. (To use
+this as a script, you'd need to remove the line breaks and escape the
+quotes.)
+
 ### Serve the docs
 
 ```

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "babel": "^6.5.2",
     "babel-cli": "^6.9.0",
     "bluebird": "^3.3.1",
-    "documentation": "^4.0.0-beta",
+    "documentation": "^4.0.0-rc.1",
     "ejs": "^2.4.1",
     "http-server": "^0.8.5",
     "semver": "^5.1.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,40 +1,64 @@
 var Promise = require('bluebird')
 var fs = Promise.promisifyAll(require('fs'))
+var path = require('path')
 var child = require('child_process')
 var ejs = require('ejs')
 var _ = require('underscore')
 var semver = require('semver')
 
+const docBin = path.resolve('./node_modules/.bin')
+const docBuild = "documentation build src/*.js --github --format html --output ${OUTPUT} --name ${NAME} --project-version ${VERSION} --external nxus-*"
+const npmBuild = "npm run build-shared-docs"
+
+// collect subdirectory names (exclude non-directories and names beginning with '.')
+function collectNames(dir) {
+  let names = []
+  for (let file of fs.readdirSync(dir))
+    if ((file[0] !== '.') && fs.statSync(path.resolve(dir, file)).isDirectory())
+      names.push(file)
+  return names
+}
+
+function trace(str, prefix = "") {
+    str = str.split('\n').map(line => prefix + line ).join('\n')
+    console.log(str)
+}
+
 var index_only = process.env.INDEX_ONLY | false
 var module_path = '../modules/'
-var modules = fs.readdirSync(module_path)
+var modules = collectNames(module_path)
 
-Promise.map(modules, function(m) {
-  if(m && m[0] == ".") return
-  console.log(m)
-  var mod_doc_dir = './'+m
-  var mod_package = JSON.parse(fs.readFileSync(module_path+m+'/package.json'))
+Promise.map(modules, (module) => {
+  trace(module)
+  let modDir = path.resolve(module_path, module),
+      mod_package = JSON.parse(fs.readFileSync(path.resolve(modDir, 'package.json'))),
+      mod_doc_dir = path.resolve('.', module),
+      mod_doc_latest = path.resolve(mod_doc_dir, 'latest')
   var name = mod_package.name
   if (!index_only) {
-    var version = mod_package.version
-    var cmd = "./node_modules/.bin/documentation build ../modules/"+m+"/src/*.js --github -f html -o "+mod_doc_dir+"/"+version+" --name '"+name+"' --project-version "+version+" --external nxus-*"
-    console.log(cmd)
-    child.execSync(cmd)
+    let cmd = mod_package.scripts['build-shared-docs'] ? npmBuild : docBuild,
+        cwd = path.resolve('../modules', module),
+        env = Object.assign({}, process.env, {
+          PATH: docBin + ':' + process.env.PATH,
+          MODULE: module,
+          NAME: name,
+          VERSION:  mod_package.version,
+          OUTPUT: path.resolve(mod_doc_dir,  mod_package.version) })
+    trace(cmd, "    ")
+    let rslt = child.execSync(cmd, { cwd, env })
+    trace(rslt.toString(), "        ")
   }
   try {
-    fs.unlinkSync(mod_doc_dir+"/latest")
+    fs.unlinkSync(mod_doc_latest)
   } catch(e) {}
-  var versions = fs.readdirSync(mod_doc_dir).reverse()
-  versions = versions.sort(function(a, b) {
-    return semver.gt(a, b) ? -1 : 1
-  })
-  fs.symlinkSync(versions[0], mod_doc_dir+"/latest", 'dir')
+  var versions = collectNames(mod_doc_dir).sort((a, b) => semver.gt(a, b) ? -1 : 1 )
+  fs.symlinkSync(versions[0], mod_doc_latest, 'dir')
   versions.unshift('latest')
   return {
-    module: m,
-    name: name,
-    package: mod_package,
-    versions: versions
+    module,
+    name,
+    versions,
+    package: mod_package
   }
 })
 .then(function(modules) {


### PR DESCRIPTION
If a module's `package.json` file defines a `build-shared-docs` script, it will be used to build the documentation for the module. (See the additions to `README.md` for more details.)

Also made the build process better at ignoring non-module files in the `modules` and `docs` directories and prettied up its trace output a bit.